### PR TITLE
Add support for parsing equations to check if they are close enough

### DIFF
--- a/daisypy/test/check_daisy.py
+++ b/daisypy/test/check_daisy.py
@@ -1,11 +1,8 @@
 '''Program for running daisy tests'''
 import argparse
-import os
-import shutil
 import subprocess
 import sys
 import tempfile
-import warnings
 
 def main():
     # pylint: disable=missing-function-docstring

--- a/daisypy/test/compare_gnuplot_files.py
+++ b/daisypy/test/compare_gnuplot_files.py
@@ -1,5 +1,4 @@
 '''Compare two dlf files using smallest meaningfull levels'''
-import warnings
 from itertools import zip_longest
 
 __all__ = [
@@ -10,13 +9,13 @@ default_lines_to_skip = frozenset(
     ()
 )
 
-default_strip_tokens = None #' \t\n*'
+DEFAULT_STRIP_TOKENS = None
 
-def compare_gnuplot_files(path1, path2,
-                      skip_lines=default_lines_to_skip,
-                      strip_tokens=default_strip_tokens,
-                      precision=1e-8,
-                      sml_identity_threshold=0.001):
+def compare_gnuplot_files(path1,
+                          path2,
+                          skip_lines=default_lines_to_skip,
+                          strip_tokens=DEFAULT_STRIP_TOKENS
+                          **_):
     '''Compare two gnuplot files
 
     Parameters
@@ -30,16 +29,9 @@ def compare_gnuplot_files(path1, path2,
     strip_tokens: str
       Tokens to strip from strings before matching against skip_lines
 
-    precision: float
-      Consider two numbers equal if their absolute difference is less than this value. Only used if
-      no SML is available
-
-    sml_identity_threshold: float
-      Consider two values identical if their difference is less than sml_identity_threshold * sml
-
     Returns
     -------
-    (errors, not_similar, not_identical) 
+    (errors, not_similar, not_identical)
       errors: list of str
       not_similar: list of str
       not_identical: list of str
@@ -49,13 +41,13 @@ def compare_gnuplot_files(path1, path2,
     not_similar = []
     keep = _drop_lines_starting_with(skip_lines, strip_tokens)
     try:
-        with open(path1) as file1, open(path2) as file2:
+        with open(path1, encoding='utf-8') as file1, open(path2, encoding='utf-8') as file2:
             log1 = filter(keep, file1)
             log2 = filter(keep, file2)
             for line1, line2 in zip_longest(log1, log2):
                 if line1 != line2:
                     not_similar.append(f'{line1} != {line2}')
-    except Exception as e:
+    except OSError as e:
         errors.append(e)
     return errors, not_similar, not_identical
 

--- a/daisypy/test/compare_log_files.py
+++ b/daisypy/test/compare_log_files.py
@@ -1,12 +1,6 @@
 '''Compare two log files using smallest meaningfull levels'''
-import warnings
+import re
 from itertools import zip_longest, dropwhile
-
-from pint.errors import UndefinedUnitError, DimensionalityError
-
-#pylint: disable=import-error, no-name-in-module
-from daisypy.test.units import daisy_ureg, dlf_unit_to_pint_unit
-from daisypy.test.sml import load_smallest_meaningful_level
 
 __all__ = [
     'compare_log_files'
@@ -31,13 +25,14 @@ default_lines_to_skip = frozenset(
     )
 )
 
-default_strip_tokens = ' \t\n*'
+DEFAULT_STRIP_TOKENS = ' \t\n*'
 
+# pylint: disable=too-many-locals ; I don't think code gets clearer by rewriting with fewer locals
 def compare_log_files(path1, path2,
                       skip_lines=default_lines_to_skip,
-                      strip_tokens=default_strip_tokens,
+                      strip_tokens=DEFAULT_STRIP_TOKENS,
                       precision=1e-8,
-                      sml_identity_threshold=0.001):
+                      **_):
     '''Compare two Daisy log files
 
     Parameters
@@ -52,33 +47,30 @@ def compare_log_files(path1, path2,
       Tokens to strip from strings before matching against skip_lines
 
     precision: float
-      Consider two numbers equal if their absolute difference is less than this value. Only used if
-      no SML is available
-
-    sml_identity_threshold: float
-      Consider two values identical if their difference is less than sml_identity_threshold * sml
+      Consider two numbers equal if their absolute difference is less than this value.
 
     Returns
     -------
-    (errors, not_similar, not_identical) 
+    (errors, not_similar, not_identical)
       errors: list of str
       not_similar: list of str
       not_identical: list of str
     '''
-    def program_not_ready(s): return not s.startswith("Storing 'daisy.log'")
-        
+    def program_not_ready(s):
+        return not s.startswith("Storing 'daisy.log'")
+
     errors = []
     not_identical = []
     not_similar = []
     keep = _drop_lines_starting_with(skip_lines, strip_tokens)
     try:
-        with open(path1) as file1, open(path2) as file2:
+        with open(path1, encoding='utf-8') as file1, open(path2, encoding='utf-8') as file2:
             log1 = filter(keep, dropwhile(program_not_ready, file1))
             log2 = filter(keep, dropwhile(program_not_ready, file2))
             for line1, line2 in zip_longest(log1, log2):
-                if line1 != line2:
+                if line1 != line2 and not _compare_equations(line1, line2, precision):
                     not_similar.append(f'{line1} != {line2}')
-    except Exception as e:
+    except OSError as e:
         errors.append(e)
     return errors, not_similar, not_identical
 
@@ -87,3 +79,22 @@ def _drop_lines_starting_with(drop_tokens, strip_tokens):
         s = s.strip(strip_tokens)
         return not any((s.startswith(token) for token in drop_tokens))
     return keep
+
+def _compare_equations(line1, line2, precision):
+    equation_pattern = re.compile(
+        r'(?P<var>[\S]+)[\s]+=[\s]+(?P<value>[\S]+)[\s]+(?P<unit>[\S]+)[\s]+(?P<comment>[\S]+)'
+    )
+    eq1 = equation_pattern.match(line1)
+    eq2 = equation_pattern.match(line2)
+    if eq1 is None or eq2 is None:
+        return False
+    if ((eq1.group('var') != eq2.group('var')) or
+        (eq1.group('unit') != eq2.group('unit')) or
+        (eq1.group('comment') != eq2.group('comment'))):
+        return False
+    try:
+        if abs(float(eq1.group('value')) - float(eq2.group('value'))) > precision:
+            return False
+    except TypeError:
+        return False
+    return True


### PR DESCRIPTION
If two lines are not identical, then we try to parse them as equations of the form
var = value unit (comment)
The lines are considered equal if the var, unit and comment parts are identical and the values are within a specificed tolerance.

Also includes some pylint cleanup